### PR TITLE
Service users need to use the system UID/GID ranges

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -110,6 +110,7 @@ class zookeeper(
   if $::zookeeper::ensure_account {
     group { $group:
       ensure => $ensure_account,
+      system => true,
     }
 
     user { $user:
@@ -118,6 +119,7 @@ class zookeeper(
       comment => 'Zookeeper',
       gid     => $group,
       shell   => $shell,
+      system  => true,
       require => Group[$group]
     }
   }


### PR DESCRIPTION
This bug has resulted in a very annoying situation, where our zookeeper servers are using UID/GID allocations in the 1000+ range, which is intended for our staff. End result, is that some servers are unable to have certain user accounts ever provisioned on them, since the user's ID in question conflicts with the one Zookeeper has grabbed for itself.

We've been lucky so far that it hasn't been a sysadmin user, but let's merge this fix in now so that any future zookeeper boxes we build are configured correctly from day 1.